### PR TITLE
library release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "maven-publish"
 }
 
-group = 'inc.kaizen.base.infrastructure'
+group = 'inc.kaizen.infra'
 version = '1.0'
 
 repositories {

--- a/src/main/kotlin/inc/kaizen/infra/podium/ApiClient.kt
+++ b/src/main/kotlin/inc/kaizen/infra/podium/ApiClient.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import com.google.gson.GsonBuilder
 import okhttp3.Call
@@ -18,7 +18,7 @@ import retrofit2.converter.scalars.ScalarsConverterFactory
  *
  * @param baseUrl The base URL for the API.
  * @param okHttpClientBuilder Optional custom OkHttpClient builder.
- * @param serializerBuilder The GsonBuilder used for serialization. Defaults to [Serializer.gsonBuilder].
+ * @param serializerBuilder The GsonBuilder used for serialization. Defaults to [inc.kaizen.infra.podium.Serializer.gsonBuilder].
  * @param callFactory Optional custom Call.Factory.
  * @param converterFactory Optional additional Converter.Factory.
  * @param timeoutConfig Timeout configuration for connect, read, and write. Defaults to 30s each.

--- a/src/main/kotlin/inc/kaizen/infra/podium/ApiResult.kt
+++ b/src/main/kotlin/inc/kaizen/infra/podium/ApiResult.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import retrofit2.HttpException
 import retrofit2.Response

--- a/src/main/kotlin/inc/kaizen/infra/podium/ByteArrayAdapter.kt
+++ b/src/main/kotlin/inc/kaizen/infra/podium/ByteArrayAdapter.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader

--- a/src/main/kotlin/inc/kaizen/infra/podium/CollectionFormats.kt
+++ b/src/main/kotlin/inc/kaizen/infra/podium/CollectionFormats.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 /**
  * Utility classes for serializing multi-value query/form parameters into

--- a/src/main/kotlin/inc/kaizen/infra/podium/DateAdapter.kt
+++ b/src/main/kotlin/inc/kaizen/infra/podium/DateAdapter.kt
@@ -1,16 +1,18 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 import com.google.gson.stream.JsonToken.NULL
 import java.io.IOException
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
-class LocalDateAdapter(private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE) : TypeAdapter<LocalDate>() {
+class DateAdapter(val formatter: DateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.getDefault())) : TypeAdapter<Date>() {
     @Throws(IOException::class)
-    override fun write(out: JsonWriter?, value: LocalDate?) {
+    override fun write(out: JsonWriter?, value: Date?) {
         if (value == null) {
             out?.nullValue()
         } else {
@@ -19,16 +21,16 @@ class LocalDateAdapter(private val formatter: DateTimeFormatter = DateTimeFormat
     }
 
     @Throws(IOException::class)
-    override fun read(out: JsonReader?): LocalDate? {
+    override fun read(out: JsonReader?): Date? {
         out ?: return null
 
-        return when (out.peek()) {
+        when (out.peek()) {
             NULL -> {
                 out.nextNull()
-                null
+                return null
             }
             else -> {
-                LocalDate.parse(out.nextString(), formatter)
+                return formatter.parse(out.nextString())
             }
         }
     }

--- a/src/main/kotlin/inc/kaizen/infra/podium/LocalDateAdapter.kt
+++ b/src/main/kotlin/inc/kaizen/infra/podium/LocalDateAdapter.kt
@@ -1,18 +1,16 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 import com.google.gson.stream.JsonToken.NULL
 import java.io.IOException
-import java.text.DateFormat
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
-class DateAdapter(val formatter: DateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.getDefault())) : TypeAdapter<Date>() {
+class LocalDateAdapter(private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE) : TypeAdapter<LocalDate>() {
     @Throws(IOException::class)
-    override fun write(out: JsonWriter?, value: Date?) {
+    override fun write(out: JsonWriter?, value: LocalDate?) {
         if (value == null) {
             out?.nullValue()
         } else {
@@ -21,16 +19,16 @@ class DateAdapter(val formatter: DateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:
     }
 
     @Throws(IOException::class)
-    override fun read(out: JsonReader?): Date? {
+    override fun read(out: JsonReader?): LocalDate? {
         out ?: return null
 
-        when (out.peek()) {
+        return when (out.peek()) {
             NULL -> {
                 out.nextNull()
-                return null
+                null
             }
             else -> {
-                return formatter.parse(out.nextString())
+                LocalDate.parse(out.nextString(), formatter)
             }
         }
     }

--- a/src/main/kotlin/inc/kaizen/infra/podium/LocalDateTimeAdapter.kt
+++ b/src/main/kotlin/inc/kaizen/infra/podium/LocalDateTimeAdapter.kt
@@ -1,16 +1,16 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 import com.google.gson.stream.JsonToken.NULL
 import java.io.IOException
-import java.time.OffsetDateTime
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-class OffsetDateTimeAdapter(private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME) : TypeAdapter<OffsetDateTime>() {
+class LocalDateTimeAdapter(private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME) : TypeAdapter<LocalDateTime>() {
     @Throws(IOException::class)
-    override fun write(out: JsonWriter?, value: OffsetDateTime?) {
+    override fun write(out: JsonWriter?, value: LocalDateTime?) {
         if (value == null) {
             out?.nullValue()
         } else {
@@ -19,7 +19,7 @@ class OffsetDateTimeAdapter(private val formatter: DateTimeFormatter = DateTimeF
     }
 
     @Throws(IOException::class)
-    override fun read(out: JsonReader?): OffsetDateTime? {
+    override fun read(out: JsonReader?): LocalDateTime? {
         out ?: return null
 
         when (out.peek()) {
@@ -28,7 +28,7 @@ class OffsetDateTimeAdapter(private val formatter: DateTimeFormatter = DateTimeF
                 return null
             }
             else -> {
-                return OffsetDateTime.parse(out.nextString(), formatter)
+                return LocalDateTime.parse(out.nextString(), formatter)
             }
         }
     }

--- a/src/main/kotlin/inc/kaizen/infra/podium/OffsetDateTimeAdapter.kt
+++ b/src/main/kotlin/inc/kaizen/infra/podium/OffsetDateTimeAdapter.kt
@@ -1,16 +1,16 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 import com.google.gson.stream.JsonToken.NULL
 import java.io.IOException
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
-class LocalDateTimeAdapter(private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME) : TypeAdapter<LocalDateTime>() {
+class OffsetDateTimeAdapter(private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME) : TypeAdapter<OffsetDateTime>() {
     @Throws(IOException::class)
-    override fun write(out: JsonWriter?, value: LocalDateTime?) {
+    override fun write(out: JsonWriter?, value: OffsetDateTime?) {
         if (value == null) {
             out?.nullValue()
         } else {
@@ -19,7 +19,7 @@ class LocalDateTimeAdapter(private val formatter: DateTimeFormatter = DateTimeFo
     }
 
     @Throws(IOException::class)
-    override fun read(out: JsonReader?): LocalDateTime? {
+    override fun read(out: JsonReader?): OffsetDateTime? {
         out ?: return null
 
         when (out.peek()) {
@@ -28,7 +28,7 @@ class LocalDateTimeAdapter(private val formatter: DateTimeFormatter = DateTimeFo
                 return null
             }
             else -> {
-                return LocalDateTime.parse(out.nextString(), formatter)
+                return OffsetDateTime.parse(out.nextString(), formatter)
             }
         }
     }

--- a/src/main/kotlin/inc/kaizen/infra/podium/ResponseExt.kt
+++ b/src/main/kotlin/inc/kaizen/infra/podium/ResponseExt.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonParseException

--- a/src/main/kotlin/inc/kaizen/infra/podium/RetryInterceptor.kt
+++ b/src/main/kotlin/inc/kaizen/infra/podium/RetryInterceptor.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import okhttp3.Interceptor
 import okhttp3.Response

--- a/src/main/kotlin/inc/kaizen/infra/podium/Serializer.kt
+++ b/src/main/kotlin/inc/kaizen/infra/podium/Serializer.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder

--- a/src/main/kotlin/inc/kaizen/infra/podium/TimeoutConfig.kt
+++ b/src/main/kotlin/inc/kaizen/infra/podium/TimeoutConfig.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import java.util.concurrent.TimeUnit
 

--- a/src/test/kotlin/inc/kaizen/infra/podium/AdapterTests.kt
+++ b/src/test/kotlin/inc/kaizen/infra/podium/AdapterTests.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter

--- a/src/test/kotlin/inc/kaizen/infra/podium/ApiClientTest.kt
+++ b/src/test/kotlin/inc/kaizen/infra/podium/ApiClientTest.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/inc/kaizen/infra/podium/ApiResultTest.kt
+++ b/src/test/kotlin/inc/kaizen/infra/podium/ApiResultTest.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/inc/kaizen/infra/podium/CollectionFormatsTest.kt
+++ b/src/test/kotlin/inc/kaizen/infra/podium/CollectionFormatsTest.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/inc/kaizen/infra/podium/RetryInterceptorTest.kt
+++ b/src/test/kotlin/inc/kaizen/infra/podium/RetryInterceptorTest.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/inc/kaizen/infra/podium/SerializerTest.kt
+++ b/src/test/kotlin/inc/kaizen/infra/podium/SerializerTest.kt
@@ -1,4 +1,4 @@
-package inc.kaizen.base.infrastructure
+package inc.kaizen.infra.podium
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe


### PR DESCRIPTION
This pull request reorganizes the codebase by moving all infrastructure-related files from the `inc.kaizen.base.infrastructure` package to a new package, `inc.kaizen.infra.podium`. This affects both the main source files and their corresponding tests. Additionally, import statements and references are updated to reflect the new package structure.

**Package and File Organization:**

* All Kotlin files under `src/main/kotlin/inc/kaizen/base/infrastructure/` have been moved to `src/main/kotlin/inc/kaizen/infra/podium/`, with package declarations updated accordingly. This includes files such as `ApiClient.kt`, `ApiResult.kt`, `ByteArrayAdapter.kt`, `CollectionFormats.kt`, `DateAdapter.kt`, `LocalDateAdapter.kt`, `LocalDateTimeAdapter.kt`, `OffsetDateTimeAdapter.kt`, `ResponseExt.kt`, `RetryInterceptor.kt`, `Serializer.kt`, and `TimeoutConfig.kt`. [[1]](diffhunk://#diff-9b0424e67bcbfd0f14b7e844c50c776737f11c79adaa11b16c5e3fbe48deff68L1-R1) [[2]](diffhunk://#diff-e3a61ff7033a6b6b97ed6c8e6d133df5a08ea2698c2b4edef5d74eb4750c2856L1-R1) [[3]](diffhunk://#diff-cfd8f66c09e7ab41efdc2836304cc9cb0d88e533fd64cfd0811f10ce303c7decL1-R1) [[4]](diffhunk://#diff-48bd33c52805e3cb05ce660cd30a38907e34e238bd63ccdc7ec744da3317d808L1-R1) [[5]](diffhunk://#diff-6c0559893c7e97de8d21393290a30278eb5b9b9a4e0661071b8a3a9440a14b06L1-R1) [[6]](diffhunk://#diff-3338da0f446b4861e4387adcea6cf79b26da2ef0d3443ca046a282dc4a20b7b9L1-R1) [[7]](diffhunk://#diff-a09c1770077c7ca462b9ba211bb806ac9768e8a2ffb2c5d8c0b299ef6a291417L1-R1) [[8]](diffhunk://#diff-edd39c74c27a6371a59e87262c8e801c412c4c0f9b6a37dcfd14053a6fd0874dL1-R1) [[9]](diffhunk://#diff-a49de516c6b136dfcdb96ed72248ff4f1a8b4fb9ec7805586a057117beda0402L1-R1) [[10]](diffhunk://#diff-1d05230eaf0d595e6585a33bb3daa675d6c6f9f0ce445644d2d92bee242b9301L1-R1) [[11]](diffhunk://#diff-eb599392d28597e5b6df541d825ff2e2863ec9963a4eb56f35bf84c36fe6520aL1-R1) [[12]](diffhunk://#diff-81fe3bffabfafdaa33ce95c04f9793d7df1618fc361a866270c1433e16e60cb7L1-R1)

* All related test files under `src/test/kotlin/inc/kaizen/base/infrastructure/` have been moved to `src/test/kotlin/inc/kaizen/infra/podium/`, with package declarations updated. This affects files such as `AdapterTests.kt`, `ApiClientTest.kt`, `ApiResultTest.kt`, `CollectionFormatsTest.kt`, `RetryInterceptorTest.kt`, and `SerializerTest.kt`. [[1]](diffhunk://#diff-54b939b8a69a4e59d2a212d931ade8837c3694c07913b0ac754cfa35bf316c91L1-R1) [[2]](diffhunk://#diff-3d141cc3b196d01b04922242f82cf80a7a0241cd8e084b6b13a9d4c87ab21e94L1-R1) [[3]](diffhunk://#diff-9705e86a96d904d0c3458702fb01aaa4ae130a885ab7c2ed7dc1401aee4fe766L1-R1) [[4]](diffhunk://#diff-479bd6cec4b2a085883c3e5fda6d3a178cbc8d2071597fef0ff927f8d9c13520L1-R1) [[5]](diffhunk://#diff-504aa3d5c4e71a9b3147c70a7c1d3d0c77ec93c0ae1258841818fccd7e223c17L1-R1) [[6]](diffhunk://#diff-01dde9546eee5118b98d2f79cc0d092870a56432a06cdf0706076cd6ec025c5bL1-R1)

**Code Reference Updates:**

* Internal references and documentation comments have been updated to use the new package path, such as changing references to `Serializer.gsonBuilder` to `inc.kaizen.infra.podium.Serializer.gsonBuilder` in `ApiClient.kt`.

This change is primarily organizational and does not alter the logic or behavior of the code, but it improves project structure and clarity.